### PR TITLE
Add 'Archive All' button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 
 group :test do
   gem 'rake', '~> 12.0'
+  gem 'factory_girl'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
     faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
@@ -193,6 +195,7 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   dotenv-rails
+  factory_girl
   font-awesome-rails
   jquery-rails
   listen (~> 3.0.5)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require bootstrap-sprockets
 //= require_tree .
 
 document.addEventListener("turbolinks:load", function() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,7 @@ html {
 .sync{
   margin-right: 0px;
 }
+
+.dropdown {
+  display: inline-block;
+}

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -29,6 +29,11 @@ class NotificationsController < ApplicationController
     redirect_to root_path(type: params[:type], repo: params[:repo])
   end
 
+  def archive_all
+    current_user.archive_all
+    redirect_to root_path
+  end
+
   def unarchive
     notification = Notification.find(params[:id])
     notification.update_attributes(archived: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
     update_attributes(github_attributes)
   end
 
+  def archive_all
+    notifications.each { |n| n.update_attributes(archived: true) }
+  end
+
   def github_client
     return @github_client if defined?(@github_client)
     @github_client = Octokit::Client.new(access_token: access_token, auto_paginate: true)

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,6 +4,15 @@
       <a class="navbar-brand" href="/">
         <%= fa_icon 'envelope' %> Octobox
       </a>
+      <div class="dropdown navbar-btn">
+        <button class="btn btn-default dropdown-toggle" type="button" id="moreMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          More
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="moreMenu">
+          <li><a href="/notifications/all/archive">Archive All</a></li>
+        </ul>
+      </div>
       <a href="/sync" data-turbolinks="false" class='btn btn-default navbar-btn navbar-right sync'>
         <%= fa_icon 'refresh' %>
       </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   match '/auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
 
+  get '/notifications/all/archive', to: 'notifications#archive_all'
   get '/notifications/:id/archive', to: 'notifications#archive'
   get '/notifications/:id/unarchive', to: 'notifications#unarchive'
   get '/notifications/:id/star', to: 'notifications#star'

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -15,4 +15,18 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template 'notifications/index'
   end
+
+  test 'archives all notifications' do
+    user = users(:andrew)
+    5.times.each { create(:notification, user: user, archived: false) }
+
+    sign_in_as(user)
+
+    get '/notifications/all/archive'
+    assert_response :redirect
+
+    user.notifications.each do |n|
+      assert_equal n.archived, true
+    end
+  end
 end

--- a/test/factories/notification.rb
+++ b/test/factories/notification.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :notification do
+    repository_id 930405
+    repository_full_name "andrew/octobox"
+    subject_title "Test"
+    subject_url "https://api.github.com/repos/andrew/octobox/issues/123"
+    subject_type "Issue"
+    reason "subscribed"
+    unread true
+    updated_at "2015-06-22 14:37:57"
+    last_read_at "2015-06-22 13:34:48 UTC"
+    url "https://api.github.com/notifications/threads/930405"
+    archived false
+    starred false
+  end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user do
-    github_id 1234
-    access_token '54c543ffd45343fg5434fgg556ff553232gg57890v'
+    github_id { rand(0..5000) }
+    access_token { SecureRandom.hex(15) }
     github_login 'andrew'
   end
 end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :user do
+    github_id 1234
+    access_token '54c543ffd45343fg5434fgg556ff553232gg57890v'
+    github_login 'andrew'
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -53,4 +53,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user.github_client.class, Octokit::Client
     assert_equal user.github_client.access_token, user.access_token
   end
+
+  test '#archive_all archives all notifications' do
+    user = users(:andrew)
+    5.times.each { create(:notification, user: user, archived: false) }
+    user.archive_all
+
+    user.notifications.each do |n|
+      assert_equal n.archived, true
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,12 +5,17 @@ require 'rails/test_help'
 
 Dir[Rails.root.join('test/support/**/*.rb')].each { |f| require f }
 
+FactoryGirl.find_definitions
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  include FactoryGirl::Syntax::Methods
 end
+
+
 
 module SignInHelper
   def sign_in_as(user)


### PR DESCRIPTION
While fiddling about, I thought this may be useful to nuke all notifications and start from scratch. Influenced by the Gmail interface, I've put the button under a 'More' submenu to prevent it from being clicked accidentally.

I've also added `factory_girl` as a test dependency to make creating database-level objects a bit easier.