### PR TITLE
Only fetch updated notifications since the last sync

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem 'factory_girl'
   gem 'simplecov'
   gem 'codeclimate-test-reporter'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     codeclimate-test-reporter (1.0.3)
       simplecov
     concurrent-ruby (1.0.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     docile (1.1.5)
     dotenv (2.1.1)
@@ -68,6 +70,7 @@ GEM
       railties (>= 3.2, < 5.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.1)
     hashie (3.4.6)
     i18n (0.7.0)
     jquery-rails (4.2.1)
@@ -158,6 +161,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sassc (1.11.0)
       bundler
@@ -205,6 +209,10 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webmock (2.3.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -239,6 +247,7 @@ DEPENDENCIES
   turbolinks
   uglifier
   web-console
+  webmock
 
 RUBY VERSION
    ruby 2.3.3p222

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,7 +13,57 @@ class Notification < ApplicationRecord
   scope :status,   ->(status)       { where(unread: status) }
 
   paginates_per 20
-  
+
+  class << self
+    def download(user)
+      timestamp = Time.current
+
+      fetch_notifications(user) do |notification|
+        begin
+          n = find_or_create_by(github_id: notification.id)
+
+          if n.archived && n.updated_at < notification.updated_at
+            n.archived = false
+          end
+
+          attrs = {
+            user_id: user.id,
+            repository_id: notification.repository.id,
+            repository_full_name: notification.repository.full_name,
+            subject_title: notification.subject.title,
+            subject_url: notification.subject.url,
+            subject_type: notification.subject.type,
+            reason: notification.reason,
+            unread: notification.unread,
+            updated_at: notification.updated_at,
+            last_read_at: notification.last_read_at,
+            url: notification.url
+          }
+
+          n.update(attrs)
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
+      end
+
+      user.touch(:last_synced_at, time: timestamp)
+    end
+
+    private
+
+    def fetch_notifications(user)
+      user.github_client.notifications(fetch_params(user)).each { |n| yield n }
+    end
+
+    def fetch_params(user)
+      if user.last_synced_at?
+        { all: true, since: user.last_synced_at.iso8601 }
+      else
+        { all: true, since: 1.month.ago.iso8601 }
+      end
+    end
+  end
+
   def web_url
     subject_url.gsub('https://api.github.com/repos', 'https://github.com')
                .gsub('/pulls/', '/pull/')
@@ -22,24 +72,5 @@ class Notification < ApplicationRecord
 
   def repo_url
     "https://github.com/#{repository_full_name}"
-  end
-
-  def self.download(user)
-    user.github_client.notifications(all: true).each do |notification|
-      n = Notification.find_or_create_by({github_id: notification.id})
-      n.archived = false if n.archived && n.updated_at < notification.updated_at
-      n.update_attributes({
-        user_id: user.id,
-        repository_id: notification.repository.id,
-        repository_full_name: notification.repository.full_name,
-        subject_title: notification.subject.title,
-        subject_url: notification.subject.url,
-        subject_type: notification.subject.type,
-        reason: notification.reason,
-        unread: notification.unread,
-        updated_at: notification.updated_at,
-        last_read_at: notification.last_read_at,
-        url: notification.url})
-    end
   end
 end

--- a/db/migrate/20161219205118_add_last_synced_at_to_users.rb
+++ b/db/migrate/20161219205118_add_last_synced_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSyncedAtToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :last_synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161218132847) do
+ActiveRecord::Schema.define(version: 20161219205118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,11 +36,12 @@ ActiveRecord::Schema.define(version: 20161218132847) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "github_id",    null: false
-    t.string   "access_token", null: false
-    t.string   "github_login", null: false
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.integer  "github_id",      null: false
+    t.string   "access_token",   null: false
+    t.string   "github_login",   null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.datetime "last_synced_at"
     t.index ["access_token"], name: "index_users_on_access_token", unique: true, using: :btree
     t.index ["github_id"], name: "index_users_on_github_id", unique: true, using: :btree
   end

--- a/test/fixtures/files/notifications.json
+++ b/test/fixtures/files/notifications.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "1",
+    "repository": {
+      "id": 930405,
+      "owner": {
+        "login": "andrew",
+        "id": 1,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/1060",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/andrew",
+        "html_url": "https://github.com/andrew",
+        "followers_url": "https://api.github.com/users/andrew/followers",
+        "following_url": "https://api.github.com/users/andrew/following{/other_user}",
+        "gists_url": "https://api.github.com/users/andrew/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/andrew/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/andrew/subscriptions",
+        "organizations_url": "https://api.github.com/users/andrew/orgs",
+        "repos_url": "https://api.github.com/users/andrew/repos",
+        "events_url": "https://api.github.com/users/andrew/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/andrew/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "name": "octobox",
+      "full_name": "andrew/octobox",
+      "description": "Take back control of your GitHub Notifications",
+      "private": false,
+      "fork": false,
+      "url": "https://api.github.com/repos/andrew/octobox",
+      "html_url": "https://github.com/andrew/octobox"
+    },
+    "subject": {
+      "title": "UI Updates",
+      "url": "https://api.github.com/repos/andrew/octobox/issues/56",
+      "latest_comment_url": "https://api.github.com/repos/andrew/octobox/issues/comments/123",
+      "type": "Issue"
+    },
+    "reason": "subscribed",
+    "unread": true,
+    "updated_at": "2016-12-19T22:01:45Z",
+    "last_read_at": "2016-12-19T22:01:45Z",
+    "url": "https://api.github.com/notifications/threads/1"
+  }
+]

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,7 +1,33 @@
 require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    notifications_url = %r{https://api.github.com/notifications}
+
+    body     = file_fixture('notifications.json')
+    headers  = { 'Content-Type' => 'application/json' }
+    response = { status: 200, body: body, headers: headers }
+
+    stub_request(:get, notifications_url).to_return(response)
+  end
+
+  test '#download fetches one months notification when a user has not been synched before' do
+    travel_to "2016-12-19T19:00:00Z" do
+      user = users(:andrew)
+      user.last_synced_at = nil
+
+      Notification.download(user)
+
+      assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-11-19T19:00:00Z"
+    end
+  end
+
+  test '#download only fetches notifications updated since the last sync' do
+    user = users(:andrew)
+    user.last_synced_at = "2016-12-19T19:00:00Z"
+
+    Notification.download(user)
+
+    assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-12-19T19:00:00Z"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'webmock/minitest'
 
 Dir[Rails.root.join('test/support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
If you have a lot of notifications then downloading them all every time is going to be painful and probably blow the rate limit on the API.