### PR TITLE
Handle failed GitHub OAuth

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -83,3 +83,11 @@ td.keys {
   display: inline-block;
 
 }
+
+.header-flash-messages {
+  .alert {
+    margin-bottom: 0;
+    border: 0px;
+    border-radius: 0px;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,12 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    session.delete(:user_id)
+    reset_session
+    redirect_to root_path
+  end
+
+  def failure
+    flash[:error] = 'There was a problem authenticating with GitHub, please try again.'
     redirect_to root_path
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,18 @@
 module ApplicationHelper
+  def bootstrap_class_for(flash_type)
+    { success: 'alert-success', error: 'alert-danger', alert: 'alert-warning', notice: 'alert-info' }[flash_type.to_sym] || flash_type.to_s
+  end
+
+  def flash_messages
+    flash.each do |msg_type, message|
+      concat(content_tag(:div, message, class: "alert #{bootstrap_class_for(msg_type)} fade in") do
+        concat content_tag(:button, 'x', class: 'close', data: { dismiss: 'alert' })
+        concat message
+      end)
+    end
+    nil
+  end
+
   def notification_icon(subject_type)
     case subject_type
     when 'RepositoryInvitation'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,10 @@
   </head>
 
   <body>
+    <div class="header-flash-messages">
+      <%= flash_messages %>
+    </div>
+
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy', as: 'logout'
 
   match '/auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
+  match '/auth/failure',            to: 'sessions#failure', via: [:get, :post]
 
   get '/notifications/all/archive', to: 'notifications#archive_all'
   get '/notifications/:id/archive', to: 'notifications#archive'

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -33,4 +33,11 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get '/logout'
     assert_redirected_to '/'
   end
+
+  test 'GET #failure redirects to / and sets a flash message' do
+    get '/auth/failure'
+
+    assert_redirected_to '/'
+    assert_equal 'There was a problem authenticating with GitHub, please try again.', flash[:error]
+  end
 end


### PR DESCRIPTION
Fixes #64 

Right now if we try to authenticate to GitHub and it fails we return a 404 on the application.

This adds a route to the application to handle the incoming auth failure and alert the user in a friendly way that it was not successful.

## See it in action
![auth_failure](https://cloud.githubusercontent.com/assets/564113/21354390/e3a81676-c697-11e6-9636-8aa24a3d51f5.gif)
