### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ You can host your own instance of Octobox using Heroku. Heroku will ask you to p
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
+## Running Octobox for [GitHub Enterprise](https://enterprise.github.com/home)
+In order to setup Octobox for your GitHub Enterprise instance all you need you do is add your enterprise domain to the `.env` file / deployed environment.
+
+Example:
+
+```
+# Enterprise domain is https://github.foobar.com
+DOMAIN=foobar.com
+```
+
+And that's it :sparkles:
+
 ## Development
 
 The source code is hosted at [GitHub](https://github.com/andrew/octobox).

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ In order to setup Octobox for your GitHub Enterprise instance all you need you d
 Example:
 
 ```
-# Enterprise domain is https://github.foobar.com
-DOMAIN=foobar.com
+GITHUB_DOMAIN=https://github.foobar.com
 ```
 
 And that's it :sparkles:

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+if (domain = ENV.fetch('DOMAIN', nil))
+  Octokit.configure do |c|
+    c.api_endpoint = "https://github.#{domain}/api/v3"
+    c.web_endpoint = "https://github.#{domain}"
+  end
+end

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-if (domain = ENV.fetch('DOMAIN', nil))
+if (github_domain = ENV.fetch('GITHUB_DOMAIN', nil))
   Octokit.configure do |c|
-    c.api_endpoint = "https://github.#{domain}/api/v3"
-    c.web_endpoint = "https://github.#{domain}"
+    c.api_endpoint = "#{github_domain}/api/v3"
+    c.web_endpoint = github_domain
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 Rails.application.config.middleware.use OmniAuth::Builder do
+  site          = 'https://api.github.com'
+  authorize_url = 'https://github.com/login/oauth/authorize'
+  token_url     = 'https://github.com/login/oauth/access_token'
+
+  if (domain = ENV.fetch('DOMAIN', nil))
+    site          = "https://github.#{domain}/api/v3"
+    authorize_url = "https://github.#{domain}/login/oauth/authorize"
+    token_url     = "https://github.#{domain}/login/oauth/access_token"
+  end
+
   provider :github,
            Rails.application.secrets.github_client_id,
            Rails.application.secrets.github_client_secret,
+           client_options: { site: site, authorize_url: authorize_url, token_url: token_url },
            scope: ENV.fetch('GITHUB_SCOPE', 'notifications')
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,10 +4,10 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   authorize_url = 'https://github.com/login/oauth/authorize'
   token_url     = 'https://github.com/login/oauth/access_token'
 
-  if (domain = ENV.fetch('DOMAIN', nil))
-    site          = "https://github.#{domain}/api/v3"
-    authorize_url = "https://github.#{domain}/login/oauth/authorize"
-    token_url     = "https://github.#{domain}/login/oauth/access_token"
+  if (github_domain = ENV.fetch('GITHUB_DOMAIN', nil))
+    site          = "#{github_domain}/api/v3"
+    authorize_url = "#{github_domain}/login/oauth/authorize"
+    token_url     = "#{github_domain}/login/oauth/access_token"
   end
 
   provider :github,


### PR DESCRIPTION
Resolves #14 by adding support for GitHub Enterprise by allowing the user to set the `DOMAIN` environment variable.

Not sure about the best way to test this so I'd ❤️ some suggestions 😄

/cc @andrew 