### PR TITLE
Update Sync and Archive All to use POST routes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,12 @@ html {
   min-height: 100%;
 }
 
+html.turbolinks-progress-bar::before {
+  height: 2px !important;
+  background-color: #77b6ff !important;
+  box-shadow: 0 0 10px rgba(#77b6ff, 0.7) !important;
+}
+
 .table > tbody > tr:first-child > td {
   border-top: none;
 }

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,7 +1,13 @@
 <tr class='<%= notification.unread ? 'active' : '' %>'>
   <td>
-    <input type="checkbox" name="" title='<%= notification.archived ? 'Unarchive' : 'Archive' %>' class='<%= notification.archived ? 'unarchive' : 'archive' %>' value="<%= notification.id %>"
-           <% if notification.archived %> checked <% end %>>
+    <%= check_box_tag(
+      '',
+      notification.id,
+      notification.archived,
+      title: (notification.archived ? 'Unarchive' : 'Archive'),
+      class: (notification.archived ? 'unarchive' : 'archive')
+    )
+  %>
   </td>
   <td>
     <%= fa_icon( notification.starred ? "star" : "star-o", class: "toggle-star star", data: { id: notification.id }) %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -42,7 +42,7 @@
           <%= octicon 'list-unordered', :height => 16 %>
         </button>
 
-        <%= link_to sync_notifications_path, class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
+        <%= link_to sync_notifications_path, class: 'btn btn-default sync', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-turbolinks' => false, 'data-animation' => 'false', 'data-position' => 'bottom', 'title' => 'Refresh list', method: :post do %>
           <%= octicon 'sync', :height => 16 %>
         <% end %>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,19 +1,19 @@
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-default" data-turbolinks="false">
   <div class="container-fluid">
     <div class="navbar-default">
       <a class="navbar-brand" href="/">
         <%= fa_icon 'envelope' %> Octobox
       </a>
-      <a href="/sync" data-turbolinks="false" class='btn btn-default navbar-btn navbar-right sync'>
+      <%= link_to sync_notifications_path, class: 'btn btn-default navbar-btn navbar-right sync', method: :post do %>
         <%= fa_icon 'refresh' %>
-      </a>
+      <% end %>
       <div class="dropdown navbar-btn navbar-right">
         <button class="btn btn-default dropdown-toggle" type="button" id="moreMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           Menu
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" aria-labelledby="moreMenu">
-          <li><a href="/notifications/all/archive">Archive All</a></li>
+          <li><%= link_to 'Archive all', archive_notifications_path, method: :post %></li>
           <li><%= link_to 'Support', "https://github.com/andrew/octobox/issues" %></li>
           <li><%= link_to 'Logout', logout_path %></li>
         </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
-  get '/login', to: 'sessions#new', as: 'login'
-  get '/logout', to: 'sessions#destroy', as: 'logout'
-
-  match '/auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
-  match '/auth/failure',            to: 'sessions#failure', via: [:get, :post]
-
-  get '/notifications/all/archive', to: 'notifications#archive_all'
-  get '/notifications/:id/archive', to: 'notifications#archive'
-  get '/notifications/:id/unarchive', to: 'notifications#unarchive'
-  get '/notifications/:id/star', to: 'notifications#star'
-  get '/sync', to: 'notifications#sync'
   root to: 'notifications#index'
+
+  get :login,  to: 'sessions#new'
+  get :logout, to: 'sessions#destroy'
+
+  scope :auth do
+    match '/:provider/callback', to: 'sessions#create',  via: [:get, :post]
+    match :failure,              to: 'sessions#failure', via: [:get, :post]
+  end
+
+  resources :notifications, only: [] do
+    collection do
+      post :archive, to: 'notifications#archive_all'
+      post :sync
+    end
+
+    member do
+      get :archive
+      get :unarchive
+      get :star
+    end
+  end
 end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -22,7 +22,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
 
-    get '/notifications/all/archive'
+    post '/notifications/archive'
     assert_response :redirect
 
     user.notifications.each do |n|
@@ -36,7 +36,6 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     25.times.each { create(:notification, user: user, archived: false) }
 
     get '/'
-    
     assert_equal assigns(:notifications).length, 20
   end
 end


### PR DESCRIPTION
🚧 ~~Do not merge until after #81~~ 🚧 (It's merged ✨ )

Part of https://github.com/andrew/octobox/issues/76

This updates the `/sync` route and the archive all routes to use `POST` instead of `GET`