### PR TITLE
Refactor Complex Methods to Lower Cyclomatic Complexity

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,13 +13,17 @@ class NotificationsController < ApplicationController
     @unread_repositories = scope.distinct.group(:repository_full_name).count
     @starred             = scope.starred.count
 
-    scopes = {params[:repo] => scope.repo(params[:repo]), params[:reason] => scope.reason(params[:reason]),
-       params[:type] => scope.type(params[:type]), params[:status] => scope.status(params[:status]),
-       params[:starred] => scope.starred}
+    scopes = {
+      params[:repo]    => scope.repo(params[:repo]),
+      params[:reason]  => scope.reason(params[:reason]),
+      params[:type]    => scope.type(params[:type]),
+      params[:status]  => scope.status(params[:status]),
+      params[:starred] => scope.starred
+    }
 
-    scopes.each do |k, v|
-      if k.present?
-        scope = v
+    scopes.each do |param_value, sub_scope|
+      if param_value.present?
+        scope = sub_scope
       end
     end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,8 +4,8 @@ class NotificationsController < ApplicationController
   before_action :render_home_page_unless_authenticated, only: [:index]
 
   def index
-    scope = current_user.notifications
-    scope = params[:archive].present? ? scope.archived : scope.inbox
+    notifications = current_user.notifications
+    scope = params[:archive].present? ? notifications.archived : notifications.inbox
 
     @types               = scope.distinct.group(:subject_type).count
     @statuses            = scope.distinct.group(:unread).count
@@ -13,11 +13,15 @@ class NotificationsController < ApplicationController
     @unread_repositories = scope.distinct.group(:repository_full_name).count
     @starred             = scope.starred.count
 
-    scope = scope.repo(params[:repo])     if params[:repo].present?
-    scope = scope.reason(params[:reason]) if params[:reason].present?
-    scope = scope.type(params[:type])     if params[:type].present?
-    scope = scope.status(params[:status]) if params[:status].present?
-    scope = scope.starred                 if params[:starred].present?
+    scopes = {params[:repo] => scope.repo(params[:repo]), params[:reason] => scope.reason(params[:reason]),
+       params[:type] => scope.type(params[:type]), params[:status] => scope.status(params[:status]),
+       params[:starred] => scope.starred}
+
+    scopes.each do |k, v|
+      if k.present?
+        scope = v
+      end
+    end
 
     @notifications = scope.newest.page(params[:page])
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,8 +4,8 @@ class NotificationsController < ApplicationController
   before_action :render_home_page_unless_authenticated, only: [:index]
 
   def index
-    notifications = current_user.notifications
-    scope = params[:archive].present? ? notifications.archived : notifications.inbox
+    scope = current_user.notifications
+    scope = params[:archive].present? ? scope.archived : scope.inbox
 
     @types               = scope.distinct.group(:subject_type).count
     @statuses            = scope.distinct.group(:unread).count
@@ -13,19 +13,11 @@ class NotificationsController < ApplicationController
     @unread_repositories = scope.distinct.group(:repository_full_name).count
     @starred             = scope.starred.count
 
-    scopes = {
-      params[:repo]    => scope.repo(params[:repo]),
-      params[:reason]  => scope.reason(params[:reason]),
-      params[:type]    => scope.type(params[:type]),
-      params[:status]  => scope.status(params[:status]),
-      params[:starred] => scope.starred
-    }
-
-    scopes.each do |param_value, sub_scope|
-      if param_value.present?
-        scope = sub_scope
-      end
-    end
+    scope = scope.repo(params[:repo])     if params[:repo].present?
+    scope = scope.reason(params[:reason]) if params[:reason].present?
+    scope = scope.type(params[:type])     if params[:type].present?
+    scope = scope.status(params[:status]) if params[:status].present?
+    scope = scope.starred                 if params[:starred].present?
 
     @notifications = scope.newest.page(params[:page])
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,34 +14,16 @@ module ApplicationHelper
   end
 
   def notification_icon(subject_type)
-    case subject_type
-    when 'RepositoryInvitation'
-      'mail-read'
-    when 'Issue'
-      'issue-opened'
-    when 'PullRequest'
-      'git-pull-request'
-    when 'Commit'
-      'git-commit'
-    end
+    subject_types = {'RepositoryInvitation' => 'mail-read', 'Issue' => 'issue-opened',
+      'PullRequest' => 'git-pull-request', 'Commit' => 'git-commit'}
+
+    subject_types[subject_type]
   end
 
   def reason_label(reason)
-    case reason
-    when 'comment'
-      'primary'
-    when 'author'
-      'success'
-    when 'state_change'
-      'info'
-    when 'mention'
-      'warning'
-    when 'assign'
-      'danger'
-    when 'subscribed'
-      'default'
-    else
-      'default'
-    end
+    reasons = {'comment' => 'primary', 'author' => 'success', 'state_change' => 'info', 'mention' => 'warning',
+       'assign' => 'danger' }
+    reasons.default = 'default'
+    reasons[reason]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,4 @@
 module ApplicationHelper
-
   REASON_LABELS = {
     'comment'      => 'primary',
     'author'       => 'success',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,20 @@
 module ApplicationHelper
+
+  REASON_LABELS = {
+    'comment'      => 'primary',
+    'author'       => 'success',
+    'state_change' => 'info',
+    'mention'      => 'warning',
+    'assign'       => 'danger'
+  }.freeze
+
+  SUBJECT_TYPES = {
+    'RepositoryInvitation' => 'mail-read',
+    'Issue'                => 'issue-opened',
+    'PullRequest'          => 'git-pull-request',
+    'Commit'               => 'git-commit'
+  }.freeze
+
   def bootstrap_class_for(flash_type)
     { success: 'alert-success', error: 'alert-danger', alert: 'alert-warning', notice: 'alert-info' }[flash_type.to_sym] || flash_type.to_s
   end
@@ -14,16 +30,10 @@ module ApplicationHelper
   end
 
   def notification_icon(subject_type)
-    subject_types = {'RepositoryInvitation' => 'mail-read', 'Issue' => 'issue-opened',
-      'PullRequest' => 'git-pull-request', 'Commit' => 'git-commit'}
-
-    subject_types[subject_type]
+    SUBJECT_TYPES[subject_type]
   end
 
   def reason_label(reason)
-    reasons = {'comment' => 'primary', 'author' => 'success', 'state_change' => 'info', 'mention' => 'warning',
-       'assign' => 'danger' }
-    reasons.default = 'default'
-    reasons[reason]
+    REASON_LABELS.fetch(reason, 'default')
   end
 end


### PR DESCRIPTION
This is a small refactor that removes some of the branching from the methods that are flagged by Rubocop for having high cyclomatic complexity. The subject_type method was not flagged, but following the pattern from the refactor for reason_name seemed easier to follow.