### PR TITLE
Implement a more visually pleasing menu for small screens

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -67,6 +67,9 @@ $(document).on('click', '[data-toggle="offcanvas"]', function () {
   $('.row-offcanvas').toggleClass('active')
 });
 
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
+if(!('ontouchstart' in window))
+{
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  })
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,8 +29,44 @@ html {
   }
 }
 
+.navbar-toggle {
+  border: none;
+  padding: 0;
+  margin-top: 12px;
+}
+
 .navbar-avatar {
   margin-top: -3px;
+}
+
+@media (max-width: $screen-xs-max) {
+  .navbar-nav .dropdown .dropdown-menu {
+    display: block;
+    position: static;
+    float: none;
+    width: auto;
+    margin-top: 0;
+    background-color: transparent;
+    border: 0;
+    box-shadow: none;
+    > li > a {
+      color: lighten($gray-light, 15%);
+      line-height: 20px;
+      padding: 5px 15px 5px 25px;
+      &:hover,
+      &:focus {
+        color: #fff;
+        background-color: transparent;
+      }
+    }
+    > li > a,
+    .dropdown-header {
+      padding: 5px 15px 5px 25px;
+    }
+    .divider {
+      background-color: #090909;
+    }
+  }
 }
 
 .table > tbody > tr:first-child > td {

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,9 +4,7 @@
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#octobox-menu" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <%= image_tag current_user.github_avatar_url + "?size=40", width: 32, class: 'img-rounded navbar-avatar' %>
       </button>
       <a class="navbar-brand" href="/">
         <%= octicon 'octoface', height: 22 %> Octobox
@@ -17,18 +15,17 @@
     <div class="collapse navbar-collapse" id="octobox-menu">
       <ul class="nav navbar-nav navbar-right">
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          <a href="#" class="dropdown-toggle hidden-xs" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
             <%= image_tag current_user.github_avatar_url + "?size=40", width: 20, class: 'img-rounded navbar-avatar' %>
-            <%= current_user.github_login %> <span class="caret"></span>
+            <%= current_user.github_login %> <span class="caret hidden-xs"></span>
           </a>
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li><%= link_to 'GitHub Dashboard', "https://github.com/" %></li>
-            <li><%= link_to 'Octobox Support', "https://github.com/andrew/octobox/issues" %></li>
+          <ul class="dropdown-menu">
+            <li><%= link_to 'GitHub Dashboard', "https://github.com/", target: "_blank" %></li>
+            <li><%= link_to 'Octobox Support', "https://github.com/andrew/octobox/issues", target: "_blank" %></li>
             <li role="separator" class="divider"></li>
             <li><%= link_to 'Logout', logout_path %></li>
           </ul>
-
-
+        </li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->


### PR DESCRIPTION
This refactors some of the weirdness from andrew/octobox#81

![octomenu](https://cloud.githubusercontent.com/assets/29120/21374346/1490fe90-c6f4-11e6-90b1-a939e54e21c2.gif)
