### PR TITLE
Make the filter dots better

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,10 +92,6 @@ html.turbolinks-progress-bar::before {
   cursor: pointer;
 }
 
-.star {
-  color: #f0ad4e;
-}
-
 @media (max-width: $screen-xs-max) {
   .table-notifications tr {
     border-left: 2px solid transparent;
@@ -177,6 +173,10 @@ td.keys {
 .sidebar-icon {
   width: 1%;
   text-align: center;
+  .octicon-primitive-dot {
+    margin-top: -3px;
+    margin-bottom: -3px;
+  }
 }
 .notification-date {
   white-space: nowrap;
@@ -302,19 +302,19 @@ td.keys {
 }
 
 .text-success {
-  fill: $state-success-text;
+  fill: $brand-success;
 }
 
 .text-info {
-  fill: $state-info-text;
+  fill: $brand-info;
 }
 
 .text-warning {
-  fill: $state-warning-text;
+  fill: $brand-warning;
 }
 
 .text-danger {
-  fill: $state-danger-text;
+  fill: $brand-danger;
 }
 
 .text-default {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -243,6 +243,8 @@ td.keys {
 // Bootstrap Off Canvas
 
 @media screen and (max-width: $screen-sm-max) {
+  $sidebar-width: 250px;
+
   .row-offcanvas {
     position: relative;
     -webkit-transition: all .25s ease-out;
@@ -260,26 +262,26 @@ td.keys {
 
   .row-offcanvas-right
   .sidebar-offcanvas {
-    right: -50%; /* 6 columns */
+    right: -$sidebar-width;
   }
 
   .row-offcanvas-left
   .sidebar-offcanvas {
-    left: -50%; /* 6 columns */
+    left: -$sidebar-width;
   }
 
   .row-offcanvas-right.active {
-    right: 50%; /* 6 columns */
+    right: $sidebar-width;
   }
 
   .row-offcanvas-left.active {
-    left: 50%; /* 6 columns */
+    left: $sidebar-width;
   }
 
   .sidebar-offcanvas {
     position: absolute;
     top: 0;
-    width: 50%; /* 6 columns */
+    width: $sidebar-width;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -319,6 +319,9 @@ td.keys {
 
 .text-default {
   fill: $text-color;
+  &.sidebar-icon {
+    fill: $text-muted;
+  }
 }
 
 .octicon-star {

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -38,7 +38,7 @@
   <% @reasons.each do |reason, count| %>
     <tr>
       <td class='text-<%= reason_label(reason) %> sidebar-icon'>
-        <%= octicon 'primitive-dot', height: 16 %>
+        <%= octicon 'primitive-dot', height: 24 %>
       </td>
       <td>
         <% if params[:reason] == reason %><strong><% end %>


### PR DESCRIPTION
I assigned the wrong colors to the original dots for Author, Mention, Comment, etc.

This makes the dots a bit bigger and the colors correspond directly to the label colors used in the message list.

<img width="408" alt="octobox_and_octobox_and_briannelson_github-inbox" src="https://cloud.githubusercontent.com/assets/29120/21386130/559e00ae-c73f-11e6-846e-2cbdba52502d.png">

Before / After