### PR TITLE
Add link to inbox in the sidebar

### DIFF
--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -69,6 +69,19 @@
   <%= menu_separator unless @unread_repositories.empty? %>
   <tr>
     <td class='sidebar-icon'>
+      <%= octicon 'inbox', height: 16 %>
+    </td>
+    <td>
+      <% if !params[:archive].present? %><strong><% end %>
+      <%= link_to 'Inbox', root_path() %>
+      <% if  !params[:archive].present? %><strong><% end %>
+    </td>
+    <td class='text-center'>
+
+    </td>
+  </tr>
+  <tr>
+    <td class='sidebar-icon'>
       <%= octicon 'check', height: 16, class: 'text-success' %>
     </td>
     <td>


### PR DESCRIPTION
When in the Archive view, I could not find anyway to get back to the normal view.

*edit*: just found the `refresh` button does it... but that wasn't obvious to me.

This PR adds an 'Inbox' link in the sidebar to help the user navigate between the views.