### PR TITLE
Archive all Notifications within the context of the page

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -30,7 +30,15 @@ class NotificationsController < ApplicationController
   end
 
   def archive_all
-    current_user.archive_all
+    scope = current_user.notifications.inbox
+
+    scope = scope.repo(archive_params[:repo])     if archive_params[:repo].present?
+    scope = scope.reason(archive_params[:reason]) if archive_params[:reason].present?
+    scope = scope.type(archive_params[:type])     if archive_params[:type].present?
+    scope = scope.status(archive_params[:status]) if archive_params[:status].present?
+    scope = scope.starred                         if archive_params[:starred].present?
+
+    scope.update_all(archived: true)
     redirect_to root_path
   end
 
@@ -56,5 +64,9 @@ class NotificationsController < ApplicationController
 
   def render_home_page_unless_authenticated
     return render 'pages/home' unless logged_in?
+  end
+
+  def archive_params
+    params.permit(:repo, :reason, :type, :status, :starred)
   end
 end

--- a/app/views/notifications/_sidebar.html.erb
+++ b/app/views/notifications/_sidebar.html.erb
@@ -93,7 +93,6 @@
 
     </td>
   </tr>
-  <tr style='border:none;'><td colspan='3' style='border:none;'>&nbsp;</td></tr>
   <tr>
     <td class='sidebar-icon'>
       <%= octicon 'star', :height => 16, :class => 'star-active' %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -56,8 +56,20 @@
           <%= octicon 'sync', :height => 16 %>
         <% end %>
 
-        <% if @notifications.any? %>
-          <%= link_to 'Archive all', archive_notifications_path, class: 'btn btn-default', method: :post %>
+        <% if @notifications.any? && !params[:archive].present? %>
+          <%= link_to(
+                'Archive all',
+                archive_notifications_path(
+                  repo:    params[:repo],
+                  reason:  params[:reason],
+                  type:    params[:type],
+                  status:  params[:status],
+                  starred: params[:starred]
+                ),
+                class: 'btn btn-default',
+                method: :post
+              )
+          %>
         <% end %>
       </p>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -60,7 +60,7 @@
 
         <% if @notifications.any? && !params[:archive].present? %>
           <%= link_to(
-                (no_url_filter_parameters_present ? 'Archive all' : 'Archive list'),
+                (no_url_filter_parameters_present ? 'Archive all' : 'Archive this list'),
                 archive_notifications_path(
                   repo:    params[:repo],
                   reason:  params[:reason],

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,5 @@
+<% no_url_filter_parameters_present = (params[:archive].nil? && params[:repo].nil? && params[:type].nil? && params[:status].nil? && params[:reason].nil?) %>
+
 <nav class="navbar navbar-default navbar-inverse navbar-fixed-top">
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->
@@ -58,7 +60,7 @@
 
         <% if @notifications.any? && !params[:archive].present? %>
           <%= link_to(
-                'Archive all',
+                (no_url_filter_parameters_present ? 'Archive all' : 'Archive list'),
                 archive_notifications_path(
                   repo:    params[:repo],
                   reason:  params[:reason],
@@ -82,7 +84,7 @@
             <%= paginate @notifications %>
           </div>
         </div>
-      <% elsif params[:archive].nil? && params[:repo].nil? && params[:type].nil? && params[:status].nil? %>
+      <% elsif no_url_filter_parameters_present %>
         <div class="blankslate blankslate-spacious blankslate-clean-background">
           <%= octicon 'mail-read', height: 32, class: 'blankslate-icon' %>
           <%= octicon 'thumbsup', height: 32, class: 'blankslate-icon' %>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -2,6 +2,8 @@
 require 'test_helper'
 
 class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  setup { @user = users(:andrew) }
+
   test 'will render the home page if not authenticated' do
     get '/'
     assert_response :success
@@ -9,7 +11,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'renders the index page if authenticated' do
-    sign_in_as(users(:andrew))
+    sign_in_as(@user)
 
     get '/'
     assert_response :success
@@ -17,23 +19,19 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'archives all notifications' do
-    user = users(:andrew)
-    5.times.each { create(:notification, user: user, archived: false) }
+    5.times.each { create(:notification, user: @user, archived: false) }
 
-    sign_in_as(user)
+    sign_in_as(@user)
 
     post '/notifications/archive'
     assert_response :redirect
 
-    user.notifications.each do |n|
-      assert_equal n.archived, true
-    end
+    @user.notifications.each { |n| assert n.archived? }
   end
 
   test 'shows only 20 notifications per page' do
-    user = users(:andrew)
-    sign_in_as(user)
-    25.times.each { create(:notification, user: user, archived: false) }
+    sign_in_as(@user)
+    25.times.each { create(:notification, user: @user, archived: false) }
 
     get '/'
     assert_equal assigns(:notifications).length, 20

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -29,6 +29,19 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     @user.notifications.each { |n| assert n.archived? }
   end
 
+  test 'archives all scoped notifications' do
+    pull_request_notification = create(:notification, user: @user, subject_type: 'PullRequest')
+    issue_notification        = create(:notification, user: @user, subject_type: 'Issue')
+
+    sign_in_as(@user)
+
+    post '/notifications/archive', params: { type: 'PullRequest' }
+    assert_response :redirect
+
+    assert pull_request_notification.reload.archived?
+    refute issue_notification.reload.archived?
+  end
+
   test 'shows only 20 notifications per page' do
     sign_in_as(@user)
     25.times.each { create(:notification, user: @user, archived: false) }


### PR DESCRIPTION
Closes #75

This add the URL parameters to the Archive all post action so that we only archive in the context of what we are seeing.

I'm not super happy with this solution as I think we can DRY this up a bit, so I'd ❤️  feedback.

I also removed the Archive all button from the Archive page.

/cc @andrew 