### PR TITLE
add `o` shortcut for opening issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can use keyboard shortcuts to navigate and perform certain actions:
  - `k` - move up the list
  - `s` - star current notification
  - `y` - archive current notification
- - `Enter` - open current notification in a new window
+ - `o` or `Enter` - open current notification in a new window
 
 Press `?` for the help menu.
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,7 +46,7 @@ $( document ).ready(function() {
     if ( e.which == 89 ) { // y
       $('td.current').parent().find('.archive').click();
     }
-    if ( e.which == 13 ) { // Enter
+    if ( e.which == 13 || e.which == 79 ) { // Enter | o
       e.preventDefault();
       $('td.current').parent().find('.link')[0].click();
     }

--- a/app/views/notifications/_help-box.html.erb
+++ b/app/views/notifications/_help-box.html.erb
@@ -50,7 +50,7 @@
             </tr>
             <tr>
               <td class="keys">
-                <div class="key">Enter</div>
+                <div class="key">o</div> or <div class="key">Enter</div>
               </td>
               <td>
                 Open current notification in a new window


### PR DESCRIPTION
👋 

This PR adds `o` as a shortcut for opening issues in a new window, alongside `Enter`. This behavior is consistent with Gmail, Google Inbox, [ntl](http://ghub.io/ntl), and probably others. Vim? I dunno.