### PR TITLE
Stopgap fix for syncing old notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -62,7 +62,7 @@ class Notification < ApplicationRecord
 
     def fetch_params(user)
       if user.last_synced_at?
-        { all: true, since: user.last_synced_at.iso8601 }
+        { all: true, since: 1.week.ago.iso8601 }
       else
         { all: true, since: 1.month.ago.iso8601 }
       end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -15,13 +15,15 @@ class NotificationTest < ActiveSupport::TestCase
     end
   end
 
-  test '#download only fetches notifications updated since the last sync' do
-    user = users(:andrew)
-    user.last_synced_at = "2016-12-19T19:00:00Z"
+  test '#download fetches one weeks notification when a user has synched before' do
+    travel_to "2016-12-19T19:00:00Z" do
+      user = users(:andrew)
+      user.last_synced_at = "2016-12-19T19:00:00Z"
 
-    Notification.download(user)
+      Notification.download(user)
 
-    assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-12-19T19:00:00Z"
+      assert_requested :get, "https://api.github.com/notifications?all=true&per_page=100&since=2016-12-12T19:00:00Z"
+    end
   end
 
   test "#download will set the url for a Repository invitation correctly" do


### PR DESCRIPTION
As it's annoying me, this pr will kludge it until https://github.com/andrew/octobox/issues/125 is properly fixed :feelsgood: 