### PR TITLE
Make pagination a little more GitHubby

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -156,7 +156,7 @@ table.keyboard-mappings {
 }
 
 table.keyboard-mappings tr > td {
-    padding-bottom: 6px;
+  padding-bottom: 6px;
 }
 
 td.keys {
@@ -402,13 +402,13 @@ td.keys {
     fill: #aaa;
   }
   &.star-active {
-      fill: #f0ad4e;
-      stroke: #f0ad4e;
+    fill: #f0ad4e;
+    stroke: #f0ad4e;
   }
 }
 
 .filter-label {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 .panel-heading,
@@ -422,7 +422,7 @@ td.keys {
 }
 
 @keyframes spin {
-	to { transform: rotate(1turn); }
+  to { transform: rotate(1turn); }
 }
 
 .spinning{

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -415,11 +415,6 @@ td.keys {
 .panel-footer {
   padding: 6px 10px;
 }
-.panel-footer {
-  .pagination {
-    margin: 4px 0 0;
-  }
-}
 
 @keyframes spin {
   to { transform: rotate(1turn); }

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,9 @@
-<li>
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
-</li>
+<% if current_page.first? %>
+  <li class="disabled">
+    <span><%= raw(t 'views.pagination.first') %></span>
+  </li>
+<% else %>
+  <li>
+    <%= link_to raw(t 'views.pagination.first'), url, :remote => remote %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
 <li class='disabled'>
-  <%= content_tag :a, raw(t 'views.pagination.truncate') %>
+  <span><%= raw(t 'views.pagination.truncate') %></span>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,9 @@
-<li>
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
-</li>
+<% if current_page.last? %>
+  <li class="disabled">
+    <span><%= raw(t 'views.pagination.next') %></span>
+  </li>
+<% else %>
+  <li>
+    <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,7 +1,7 @@
 <%= paginator.render do -%>
   <ul class="pagination">
     <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
+    <%= prev_page_tag %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
         <%= page_tag page %>
@@ -9,7 +9,7 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>
-    <%= next_page_tag unless current_page.last? %>
+    <%= next_page_tag %>
     <%= last_page_tag unless current_page.last? %>
   </ul>
 <% end -%>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,6 +1,5 @@
 <%= paginator.render do -%>
   <ul class="pagination">
-    <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
@@ -10,6 +9,5 @@
       <% end -%>
     <% end -%>
     <%= next_page_tag %>
-    <%= last_page_tag unless current_page.last? %>
   </ul>
 <% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,9 @@
-<li>
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
-</li>
+<% if current_page.first? %>
+  <li class="disabled">
+    <span><%= raw(t 'views.pagination.previous') %></span>
+  </li>
+<% else %>
+  <li>
+    <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+  </li>
+<% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -103,7 +103,11 @@
         <% end %>
       </div>
 
-      <div class="container text-center">
+      <div class="text-center visible-xs-block">
+        <%= paginate @notifications, left: 1, right: 1, window: 0 %>
+      </div>
+
+      <div class="text-center visible-sm-block visible-md-block visible-lg-block visible-xl-block">
         <%= paginate @notifications %>
       </div>
     </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -86,9 +86,6 @@
           <table class='table table-hover table-notifications'>
             <%= render @notifications %>
           </table>
-          <div class="panel-footer">
-            <%= paginate @notifications %>
-          </div>
         <% elsif no_url_filter_parameters_present %>
           <div class="blankslate blankslate-spacious blankslate-clean-background">
             <%= octicon 'mail-read', height: 32, class: 'blankslate-icon' %>
@@ -104,6 +101,10 @@
             <p>You can always try <%= link_to 'refreshing', root_path %>.</p>
           </div>
         <% end %>
+      </div>
+
+      <div class="container text-center">
+        <%= paginate @notifications %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  views:
+    pagination:
+      previous: 'Previous'
+      next: 'Next'


### PR DESCRIPTION
This updates the pagination to look at little more like what the pagination looks like on GitHub.

<img width="486" alt="screen shot 2016-12-22 at 16 55 06" src="https://cloud.githubusercontent.com/assets/564113/21442316/35f7a322-c86b-11e6-90f8-0360ddb2fd38.png">

<img width="1182" alt="screen shot 2016-12-22 at 17 31 39" src="https://cloud.githubusercontent.com/assets/564113/21442553/8975485a-c86c-11e6-8135-c4ad95d9e7d1.png">


I've also made it mobile friendly by changing the window size.

/cc @briannelson for 👀 

I'm also totally cool if this doesn't get merged just thought I'd see what people thought.
